### PR TITLE
[0/n][image app cleanup] Update `.gitignore` to Exclude Precahce Manifest Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# generated precahce manifest files
+dev-dist/


### PR DESCRIPTION
### TL;DR

This PR updates the `.gitignore` file to ignore pre-cache manifest files that are generated and stored in `dev-dist` directory.

### What changed?

Three new lines (+3) are added to `.gitignore`, namely:

```
# generated pre-cache manifest files
dev-dist/
```

### How to test?

Test this by running the app (via `pnpm dev`) which would generate the files. The files should not be tracked by Git.

### Why make this change?

The change is necessary to prevent unnecessary tracking of files in the dev-dist directory by Git. This helps maintain a cleaner, more manageable code base.

---

