### PR TITLE
[1/n][image app cleanup] Update globPatterns in workbox configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import { VitePWA } from 'vite-plugin-pwa'
-import { nodePolyfills } from 'vite-plugin-node-polyfills'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { VitePWA } from "vite-plugin-pwa";
+import { nodePolyfills } from "vite-plugin-node-polyfills";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -9,27 +9,27 @@ export default defineConfig({
     nodePolyfills(),
     react(),
     VitePWA({
-      registerType: 'autoUpdate',
+      registerType: "autoUpdate",
       devOptions: {
         enabled: true
       },
       workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg}']
+				globPatterns: ["./**/*.js"],
       },
       includeAssets: [
-        'favicon.ico', 
-        'apple-touch-icon-180x180.png', 
-        'maskable-icon-512x512.svg', 
-        'pwa-64x64.png', 
-        'pwa-192x192.png', 
-        'pwa-512x512.png',
-        'logo.svg'
+        "favicon.ico", 
+        "apple-touch-icon-180x180.png", 
+        "maskable-icon-512x512.svg", 
+        "pwa-64x64.png", 
+        "pwa-192x192.png", 
+        "pwa-512x512.png",
+        "logo.svg"
       ],
       manifest: {
-        name: 'Image App',
-        short_name: 'Image App',
-        description: 'Image upload example app.',
-        theme_color: '#ffffff',
+        name: "Image App",
+        short_name: "Image App",
+        description: "Image upload example app.",
+        theme_color: "#ffffff",
         icons: [
           {
             "src": "pwa-64x64.png",


### PR DESCRIPTION
### TL;DR

This PR updates the `globPatterns` in our Vite configuration.

### What changed?

The `globPatterns` setting in the `workbox` section of our Vite config was updated from `'**/*.{js,css,html,ico,png,svg}'` to `'./**/*.js'`, optimizing to precache necessary manifest files.

### How to test?

To test this change, ensure that our Vite config correctly identifies and includes only JavaScript files when it glob matches. Also, run `pnpm dev --force` pre-commit and post-commit and the warning should disappear.

### Why make this change?

This change was made to accurately target only JavaScript files in the project. It results in a more efficient and focused file-targeting approach, improving our project's build system.

---

