### PR TITLE
[4/n][image app cleanup] Refactor: Explicit typing for React Components

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,11 +1,12 @@
-import { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
+
+import { useAccounts, useImageStorage, ImageRecord } from "../hooks";
 import UploadPreviewModal from "./UploadPreviewModal";
 import UploadButton from "./UploadButton";
 import EmptyState from "./EmptyState";
 import ImageCard from "./ImageCard";
-import { useAccounts, useImageStorage, ImageRecord } from "../hooks";
 
-const App = () => {
+const App: React.FC = () => {
   const [images, setImages] = useState<ImageRecord[]>([]);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [preview, setPreview] = useState<string | null>(null);

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,6 +1,7 @@
+import React from "react";
 import { CameraIcon } from "@heroicons/react/24/solid";
 
-const EmptyState = () => (
+const EmptyState: React.FC = () => (
   <div className="fixed inset-0 flex justify-center items-center p-4">
     <div className="text-center">
       <CameraIcon className="mx-auto h-12 w-12 text-gray-400" />

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -1,19 +1,12 @@
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
+
 import { ImageRecord } from "../hooks/useImageStorage";
 
-const ImageCard = ({
+const ImageCard: React.FC<{ image: ImageRecord; index: number, decrypt: (ciphertext: string, dataToEncryptHash: string) => Promise<string | undefined> }> = ({
   image,
   index,
   decrypt,
-}: {
-  image: ImageRecord;
-  index: number;
-  decrypt: (
-    ciphertext: string,
-    dataToEncryptHash: string,
-  ) => Promise<string | undefined>;
 }) => {
-
   const [text, setText] = useState<string | undefined>();
 
   useEffect(() => {

--- a/src/components/UploadButton.tsx
+++ b/src/components/UploadButton.tsx
@@ -1,15 +1,11 @@
 import React from "react";
 import { CameraIcon } from "@heroicons/react/24/solid";
 
-const UploadButton = ({
-  isLoading,
-  handleImageChange,
-  fileInputRef,
-}: {
-  isLoading: boolean;
-  handleImageChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  fileInputRef: React.RefObject<HTMLInputElement>;
-}) => {
+const UploadButton: React.FC<{
+	  isLoading: boolean;
+	  handleImageChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	  fileInputRef: React.RefObject<HTMLInputElement>;
+	}> = ({ isLoading, handleImageChange, fileInputRef }) => {
   return (
     <div className="fixed bottom-10 left-1/2 transform -translate-x-1/2 flex justify-center">
       {isLoading ? (

--- a/src/components/UploadPreviewModal.tsx
+++ b/src/components/UploadPreviewModal.tsx
@@ -1,16 +1,11 @@
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 
-const UploadPreviewModal = ({
-  isOpen,
-  onSubmit,
-  onCancel,
-  preview,
-}: {
+const UploadPreviewModal: React.FC<{
   isOpen: boolean;
+  preview: string | null;
   onSubmit: (title?: string, description?: string) => void;
   onCancel: () => void;
-  preview: string | null;
-}) => {
+}> = ({ isOpen, preview, onSubmit, onCancel }) => {
   const [localTitle, setLocalTitle] = useState<string | undefined>();
   const [localDescription, setLocalDescription] = useState<
     string | undefined

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./components/App.tsx";
 import { useRegisterSW } from "virtual:pwa-register/react";
-import { StytchProvider } from '@stytch/react';
-import { StytchUIClient } from '@stytch/vanilla-js';
+import { StytchProvider } from "@stytch/react";
+import { StytchUIClient } from "@stytch/vanilla-js";
 
+import App from "./components/App.tsx";
 import "./index.css";
 
-const AppUpdater = () => {
+const AppUpdater: React.FC = () => {
   const intervalMS = 1000 * 60 * 60 // 1 hour;
 
   useRegisterSW({


### PR DESCRIPTION
### TL;DR

This pull request refactors TypeScript definitions in React components.

### What changed?

- Component props were changed from a custom interface into `React.FC` props definition.
- Also, imports for `React` were modified to include the default `React` object instead of only importing hooks. 

### How to test?

Ensure all updated components are typed properly in terms of props and behave as expected.

### Why make this change?

- Review readability: enabling strict typescript linting in this stack (next few pull requests).
- Improve TypeScript declarations and support better coding practices in line with React Type best practices.

---

