### PR TITLE
[5/n][image app cleanup] Refactor: Null check for root element in `main.tsx`

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,12 +34,15 @@ const AppUpdater: React.FC = () => {
 };
 
 const stytchClient = new StytchUIClient("public-token-test-fb7aa946-fb42-46be-95ae-63505c0c5ff8");
+const rootElement = document.getElementById("root");
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <StytchProvider stytch={stytchClient}>
-      <App />
-    </StytchProvider>
-    <AppUpdater />
-  </React.StrictMode>,
-);
+rootElement
+	? ReactDOM.createRoot(rootElement).render(
+			<React.StrictMode>
+				<StytchProvider stytch={stytchClient}>
+					<App />
+				</StytchProvider>
+				<AppUpdater />
+			</React.StrictMode>,
+		)
+	: console.log("Root element not found");


### PR DESCRIPTION
### TL;DR

This PR improves how the root element is retrieved for the `React` rendering process in `main.tsx`.

### What changed?

Previously, the root element was unwrapped forcefully (could be nil). Check if `rootElement` exists.

### How to test?

To test this change, launch the application after getting the new code. There should be no visible changes, and the console should not show the `Root element not found` message unless the HTML structure is altered to remove the root element.

### Why make this change?

- Readability so when we enable strict typescript linting in this pull request stack, it isn't one massive pull request. Reviewable code.
- This change provides better error checking and logging in the situation where the root HTML element required by `React` is missing.

---

