### PR TITLE
[6/n][image app cleanup] Typesafe(r) `useImageStorage.ts` hook

### DIFF
--- a/src/hooks/useImageStorage.ts
+++ b/src/hooks/useImageStorage.ts
@@ -1,82 +1,97 @@
 import { useState, useEffect } from "react";
 
+import { ImageStorageError } from "../utils/CustomError";
+
 export interface ImageRecord {
-  url: string;
-  title?: string;
-  description?: string;
+	url: string;
+	title?: string;
+	description?: string;
+	timestamp?: Date;
 }
 
 function useImageStorage() {
-  const [db, setDb] = useState<IDBDatabase | undefined | null>(null);
+	const [db, setDb] = useState<IDBDatabase | undefined | null>(null);
 
-  useEffect(() => {
-    const idbOpen = () => {
-      const request = indexedDB.open("imagesDatabase", 1);
-      request.onupgradeneeded = (event) => {
-        const db = (event.target as IDBOpenDBRequest).result;
-        if (!db.objectStoreNames.contains("images")) {
-          db.createObjectStore("images", {
-            keyPath: "id",
-            autoIncrement: true,
-          });
-        }
-      };
+	useEffect(() => {
+		const idbOpen = () => {
+			const request = indexedDB.open("imagesDatabase", 1);
+			request.onupgradeneeded = (event) => {
+				const db = (event.target as IDBOpenDBRequest).result;
+				if (!db.objectStoreNames.contains("images")) {
+					db.createObjectStore("images", {
+						keyPath: "id",
+						autoIncrement: true,
+					});
+				}
+			};
 
-      request.onsuccess = (event) => {
-        setDb((event.target as IDBOpenDBRequest).result as IDBDatabase);
-      };
+			request.onsuccess = (event) => {
+				setDb((event.target as IDBOpenDBRequest).result as IDBDatabase);
+			};
 
-      request.onerror = (event) => {
-        console.error(
-          "IndexedDB opening error:",
-          (event.target as IDBOpenDBRequest).error,
-        );
-      };
-    };
-    idbOpen();
-  }, []);
+			request.onerror = (event) => {
+				console.error(
+					"IndexedDB opening error:",
+					(event.target as IDBOpenDBRequest).error,
+				);
+			};
+		};
+		idbOpen();
+	}, []);
 
-  async function storeImage(blob: Blob, title?: string, description?: string) {
-    if (!db) {
-      throw new Error("IndexDB is not initialized.");
-    }
+	async function storeImage(blob: Blob, title?: string, description?: string) {
+		if (!db) {
+			throw new Error("IndexDB is not initialized.");
+		}
 
-    const tx = db.transaction("images", "readwrite");
-    const store = tx.objectStore("images");
-    const timestamp = new Date();
-    const imageRecord = { blob, title, description, timestamp };
-    store.add(imageRecord);
+		const tx = db.transaction("images", "readwrite");
+		const store = tx.objectStore("images");
+		const timestamp = new Date();
+		const imageRecord: ImageRecord = {
+			url: URL.createObjectURL(blob),
+			title,
+			description,
+			timestamp,
+		};
+		store.add(imageRecord);
 
-    return new Promise((resolve, reject) => {
-      tx.oncomplete = () => resolve(imageRecord);
-      tx.onerror = () => reject(tx.error);
-    });
-  }
+		return new Promise((resolve, reject) => {
+			tx.oncomplete = () => {
+				resolve(imageRecord);
+			};
+			tx.onerror = () => {
+				reject(new ImageStorageError("[storeImage] failed to record image. ${tx.error}"));
+			};
+		});
+	}
 
-  async function fetchImages() {
-    if (!db) {
-      throw new Error("IndexDB is not initialized.");
-    }
+	async function fetchImages() {
+		if (!db) {
+			throw new Error("IndexDB is not initialized.");
+		}
 
     const tx = db.transaction("images", "readonly");
     const store = tx.objectStore("images");
 
-    return new Promise<ImageRecord[]>((resolve, reject) => {
-      const request = store.getAll();
-      request.onsuccess = () => {
-        resolve(
-          request.result.reverse().map((imgRecord) => ({
-            url: URL.createObjectURL(imgRecord.blob),
-            title: imgRecord.title,
-            description: imgRecord.description,
-          })),
-        );
-      };
-      request.onerror = () => reject(request.error);
-    });
-  }
+		return new Promise<ImageRecord[]>((resolve, reject) => {
+			const request = store.getAll();
+			request.onsuccess = () => {
+				resolve(
+					request.result.reverse().map((imageRecord: ImageRecord) => ({
+						url: imageRecord.url,
+						title: imageRecord.title,
+						description: imageRecord.description,
+						timestamp: imageRecord.timestamp,
+					})),
+				);
+			};
+			request.onerror = () => {
+				reject(new ImageStorageError("[fetchImages] failed. ${request.error.message}"));
+			};
+		});
+	}
 
-  return { storeImage, fetchImages, isLoading: !db };
+	return { storeImage, fetchImages, isLoading: !db };
 }
 
 export { useImageStorage };

--- a/src/utils/CustomError.ts
+++ b/src/utils/CustomError.ts
@@ -1,0 +1,6 @@
+export class ImageStorageError extends Error {
+	constructor(message?: string) {
+		super(message ?? "ImageStorageError");
+		this.name = "ImageStorageError";
+	}
+}


### PR DESCRIPTION
# TL;DR

- Added custom error class `ImageStorageError`
- Modified `useImageStorage` hook to include `timestamp` in Image record

# What changed?

- Added custom error class `ImageStorageError`
- Modified `useImageStorage` hook to include `timestamp` in `ImageRecord`

# How to test?

- Run tests for storing and fetching images

# Why make this change?

- Improve error handling with custom error class
- Enhance functionality by adding `timestamp` to `ImageRecord`

---

