### PR TITLE
[1/n][image ipfs] `useEncryption` hook

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef } from "react";
 
-import { useAccounts, useImageStorage, ImageRecord } from "../hooks";
+import { useAccounts, useImageStorage } from "../hooks";
 import UploadPreviewModal from "./UploadPreviewModal";
 import UploadButton from "./UploadButton";
 import EmptyState from "./EmptyState";
 import ImageCard from "./ImageCard";
+import { ImageRecord } from "../types";
 
 const App: React.FC = () => {
 	const [images, setImages] = useState<ImageRecord[]>([]);
@@ -14,7 +15,7 @@ const App: React.FC = () => {
 	const { storeImage, fetchImages, isLoading } = useImageStorage();
 	const fileInputRef = useRef<HTMLInputElement>(null);
 
-	const t = useAccounts();
+	const accountHook = useAccounts();
 
 	useEffect(() => {
 		if (!isLoading) {
@@ -45,7 +46,7 @@ const App: React.FC = () => {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const uploadImage = async (title?: string, _description?: string) => {
 		if (selectedFile) {
-			const encrypted = await t.encrypt(title ?? "no title");
+			const encrypted = await accountHook.encrypt(title ?? "no title");
 			await storeImage(selectedFile, title, JSON.stringify(encrypted));
 			const updatedImages = await fetchImages();
 			setImages(updatedImages);
@@ -71,7 +72,9 @@ const App: React.FC = () => {
 			{/* Main Content */}
 			<div className="flex-grow p-5 overflow-y-auto mt-12 mb-8">
 				<div className="mt-5 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4">
-					{images.length === 0 || !t.authMethod || !t.pkps.length ? (
+					{images.length === 0 ||
+					!accountHook.authMethod ||
+					!accountHook.pkps.length ? (
 						<EmptyState />
 					) : (
 						images.map((image, index) => (
@@ -79,7 +82,7 @@ const App: React.FC = () => {
 								key={index}
 								image={image}
 								index={index}
-								decrypt={t.decrypt}
+								decrypt={accountHook.decrypt}
 							/>
 						))
 					)}

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-import { ImageRecord } from "../hooks/useImageStorage";
+import { ImageRecord } from "../types";
 
 const ImageCard: React.FC<{
 	image: ImageRecord;
@@ -30,7 +30,7 @@ const ImageCard: React.FC<{
 			}
 		}
 		handle();
-	}, [text]);
+	}, [text, image]);
 
 	return (
 		<div key={index} className="w-full">

--- a/src/hooks/useEncryption.ts
+++ b/src/hooks/useEncryption.ts
@@ -1,0 +1,83 @@
+import { useCallback } from "react";
+import { SessionSigs } from "@lit-protocol/types";
+import { LitAbility, LitActionResource } from "@lit-protocol/auth-helpers";
+import { encryptString, decryptToString } from "@lit-protocol/lit-node-client";
+import {
+	DecryptParams,
+	EncryptParams,
+	OperationParams,
+	Operations,
+	UseEncryptionParams,
+} from "../types";
+
+export const useEncryption = () => {
+	const getSessionSigs = async (
+		params: UseEncryptionParams,
+	): Promise<SessionSigs> => {
+		const sessionSig = params.provider.getSessionSigs({
+			authMethod: params.authMethod,
+			pkpPublicKey: params.pkp,
+			sessionSigsParams: {
+				chain: "ethereum", // todo dynamic
+				resourceAbilityRequests: [
+					{
+						resource: new LitActionResource("*"),
+						ability: LitAbility.PKPSigning,
+					},
+				],
+			},
+		});
+
+		if (Object.keys(sessionSig).length === 0) {
+			throw new Error("Session signatures could not be obtained.");
+		}
+
+		return sessionSig;
+	};
+
+	const performOperation = useCallback(
+		async <T extends Operations>(
+			operation: T,
+			params: OperationParams[T],
+		): Promise<string> => {
+			const sessionSigs = await getSessionSigs(params);
+
+			switch (operation) {
+				case Operations.encrypt: {
+					const encryptParams = params as EncryptParams;
+					const result = await encryptString(
+						{
+							sessionSigs,
+							accessControlConditions: encryptParams.accessControlConditions,
+							dataToEncrypt: encryptParams.dataToEncrypt,
+							chain: "ethereum", // todo dynamic
+						},
+						encryptParams.provider.litNodeClient,
+					);
+					return result.ciphertext;
+				}
+				case Operations.decrypt: {
+					const decryptParams = params as DecryptParams;
+					const result = await decryptToString(
+						{
+							sessionSigs,
+							accessControlConditions: decryptParams.accessControlConditions,
+							ciphertext: decryptParams.ciphertext,
+							dataToEncryptHash: decryptParams.dataToDecryptHash,
+							chain: "ethereum", // todo dynamic
+						},
+						decryptParams.provider.litNodeClient,
+					);
+					return result;
+				}
+				default:
+					throw new Error("Unsupported operation.");
+			}
+		},
+		[],
+	);
+
+	return {
+		performOperation,
+	};
+};

--- a/src/hooks/useImageStorage.ts
+++ b/src/hooks/useImageStorage.ts
@@ -1,13 +1,7 @@
 import { useState, useEffect } from "react";
 
 import { ImageStorageError } from "../utils/CustomError";
-
-export interface ImageRecord {
-	url: string;
-	title?: string;
-	description?: string;
-	timestamp?: Date;
-}
+import { ImageRecord } from "../types";
 
 function useImageStorage() {
 	const [db, setDb] = useState<IDBDatabase | undefined | null>(null);

--- a/src/types/Encryption.ts
+++ b/src/types/Encryption.ts
@@ -1,0 +1,28 @@
+import { BaseProvider } from "@lit-protocol/lit-auth-client";
+import { AccessControlConditions, AuthMethod } from "@lit-protocol/types";
+
+export interface UseEncryptionParams {
+	authMethod: AuthMethod;
+	provider: BaseProvider;
+	pkp: string;
+	accessControlConditions: AccessControlConditions;
+}
+
+export interface EncryptParams extends UseEncryptionParams {
+	dataToEncrypt: string;
+}
+
+export interface DecryptParams extends UseEncryptionParams {
+	ciphertext: string;
+	dataToDecryptHash: string;
+}
+
+export enum Operations {
+	encrypt,
+	decrypt,
+}
+
+export interface OperationParams {
+	[Operations.encrypt]: EncryptParams;
+	[Operations.decrypt]: DecryptParams;
+}

--- a/src/types/ImageRecord.ts
+++ b/src/types/ImageRecord.ts
@@ -1,0 +1,6 @@
+export interface ImageRecord {
+	url: string;
+	title?: string;
+	description?: string;
+	timestamp?: Date;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from "./Encryption";
+export * from "./ImageRecord";


### PR DESCRIPTION
### TL;DR

Refactor the `useAccounts` hook by separating `encrypt` and `decrypt` into a separate hook. For testability, we'll keep `encrypt` and `decrypt` in `useAccounts` for now. Update the `ImageCard` component to use the correct `ImageRecord` type.

### What changed?

- Removed `encrypt` and `decrypt` logic out of `useAccounts` hook. (Will be re-arch but for testability keeping methods for now.
- Updated the `ImageCard` component to use the correct `ImageRecord` type

### How to test?

1. Ensure encryption works correctly in the app
2. Verify that the `ImageCard` component displays images properly

### Why make this change?

This change enhances data security by adding encryption capability to the app and improves type safety in the `ImageCard` component.

---

