### PR TITLE
Refactor encryption hook

### DIFF
--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -9,7 +9,6 @@ import {
 } from "@lit-protocol/types";
 import { useStytchUser, useStytch } from "@stytch/react";
 import { useEncryption } from "./useEncryption";
-import { Operations } from "../types";
 
 const accessControlConditions: AccessControlConditions = [
 	{
@@ -38,7 +37,7 @@ export const useAccounts = () => {
 	const [pkps, setPkps] = useState<IRelayPKP[] | IRelayPollStatusResponse[]>(
 		[],
 	);
-	const { performOperation } = useEncryption();
+	const encryption = useEncryption();
 
 	useEffect(() => {
 		async function handle() {
@@ -112,7 +111,7 @@ export const useAccounts = () => {
 				return;
 			}
 
-			const encrypted = await performOperation(Operations.encrypt, {
+			const encrypted = await encryption.encrypt({
 				provider,
 				pkp,
 				dataToEncrypt,
@@ -135,7 +134,7 @@ export const useAccounts = () => {
 				return;
 			}
 
-			const decrypted = await performOperation(Operations.decrypt, {
+			const decrypted = await encryption.decrypt({
 				provider,
 				pkp,
 				authMethod,

--- a/src/types/Encryption.ts
+++ b/src/types/Encryption.ts
@@ -16,13 +16,3 @@ export interface DecryptParams extends UseEncryptionParams {
 	ciphertext: string;
 	dataToDecryptHash: string;
 }
-
-export enum Operations {
-	encrypt,
-	decrypt,
-}
-
-export interface OperationParams {
-	[Operations.encrypt]: EncryptParams;
-	[Operations.decrypt]: DecryptParams;
-}


### PR DESCRIPTION
### TL;DR

This PR simplifies the `useEncryption` hook

### What changed?

Don't plan to add more to this hook. Lets simplify.

### How to test?

To test, redirect all requests and responses driven by the `useAccounts` and `useEncryption` hooks in your local and staging environment. Check that the login and decryption/encryption processes go through smoothly.

### Why make this change?

These changes provide a cleaner and more direct interface between the `useAccounts` and `useEncryption` hooks. This could lead to more maintainable code and improve the overall reliability of the encryption process.

---

